### PR TITLE
Floating-point Approximation task

### DIFF
--- a/src/main/java/org/academy/kata/implementation/keepCalmGirl/SixImpl.java
+++ b/src/main/java/org/academy/kata/implementation/keepCalmGirl/SixImpl.java
@@ -16,7 +16,11 @@ public class SixImpl extends Base implements ISix {
 
     @Override
     public double f(double x) {
-        return 0;
+        if (Math.abs(x) < 1) {
+            return (x / 2) - (Math.pow(x, 2) / 8) + (Math.pow(x, 3) / 16) - (Math.pow(x, 4) / 128) + (Math.pow(x, 5) / 1024) - (Math.pow(x, 6) / 8192) + (Math.pow(x, 7) / 65536);
+        } else {
+            return Math.sqrt(1 + x) - 1;
+        }
     }
 
     @Override


### PR DESCRIPTION
f: x -> sqrt(1 + x) - 1 - gives erroneous results when x is close to 0.
Given: tiny x (e.g., 1e-15).
Return: a good approximation of f(x) in the neighborhood of 0.

Note: My solution is via the approximation precision method - Power series. 